### PR TITLE
Basic 'my series': watch a series, filter the chart to watched

### DIFF
--- a/packages/pipeline/src/stages/export.ts
+++ b/packages/pipeline/src/stages/export.ts
@@ -46,6 +46,7 @@ export function exportData(
 
 	const dropped: Record<string, number> = {
 		unhydrated: 0,
+		implausibleDate: 0,
 		nonEnglish: 0,
 		aiNarrated: 0,
 		blockedAuthor: 0,
@@ -59,6 +60,12 @@ export function exportData(
 	for (const book of books) {
 		if (!book.title || !book.releaseDate) {
 			dropped.unhydrated++;
+			continue;
+		}
+		// Audible uses far-future placeholder dates (2200-01-01) for some
+		// unscheduled preorders; real preorders never sit more than ~2 years out.
+		if (Number(book.releaseDate.slice(0, 4)) > Number(now.slice(0, 4)) + 2) {
+			dropped.implausibleDate++;
 			continue;
 		}
 		if (book.language !== null && book.language !== "english") {

--- a/packages/pipeline/src/stages/validate.ts
+++ b/packages/pipeline/src/stages/validate.ts
@@ -16,11 +16,13 @@ const SnapshotSchema = z.object({
 	series: z.number().int(),
 	hydrated: z.number().int().default(0),
 	/**
-	 * Fraction of HYDRATED books with a non-null value, per key field.
-	 * Unhydrated stubs (fresh close-series volumes) are pending work, not
-	 * regressions — counting them here once discarded a whole bootstrap run.
+	 * ABSOLUTE count of books with a non-null value, per key field.
+	 * Ratios proved composition-sensitive: hydrating the long tail (preorders
+	 * without cover art yet) diluted coverage and false-failed healthy runs.
+	 * Counts only fall when existing values are destroyed — which is the one
+	 * thing merge-only writes should make impossible, so a drop means a bug.
 	 */
-	fieldCoverage: z.record(z.string(), z.number()),
+	fieldCovered: z.record(z.string(), z.number()).default({}),
 });
 export type Snapshot = z.infer<typeof SnapshotSchema>;
 
@@ -29,17 +31,16 @@ const COVERAGE_FIELDS = ["title", "releaseDate", "coverUrl", "rating"] as const;
 export function takeSnapshot(corpus: Corpus, now: string): Snapshot {
 	const books = [...corpus.books.values()];
 	const hydrated = books.filter((b) => b.meta.lastHydratedAt !== null);
-	const fieldCoverage: Record<string, number> = {};
+	const fieldCovered: Record<string, number> = {};
 	for (const field of COVERAGE_FIELDS) {
-		const covered = hydrated.filter((b) => b[field] !== null).length;
-		fieldCoverage[field] = hydrated.length === 0 ? 0 : covered / hydrated.length;
+		fieldCovered[field] = books.filter((b) => b[field] !== null).length;
 	}
 	return {
 		takenAt: now,
 		books: books.length,
 		series: corpus.series.size,
 		hydrated: hydrated.length,
-		fieldCoverage,
+		fieldCovered,
 	};
 }
 
@@ -74,12 +75,12 @@ export function validate(
 				`series shrank ${seriesShrink.toFixed(1)}% (${prev.series} → ${snapshot.series}), max allowed ${config.validate.maxSeriesShrinkPct}%`,
 			);
 		}
-		for (const [field, prevCov] of Object.entries(prev.fieldCoverage)) {
-			const nowCov = snapshot.fieldCoverage[field] ?? 0;
-			const regress = (prevCov - nowCov) * 100;
-			if (regress > config.validate.maxNullRegressPct) {
+		for (const [field, prevCount] of Object.entries(prev.fieldCovered ?? {})) {
+			const nowCount = snapshot.fieldCovered[field] ?? 0;
+			const dropPct = prevCount === 0 ? 0 : ((prevCount - nowCount) / prevCount) * 100;
+			if (dropPct > config.validate.maxNullRegressPct) {
 				problems.push(
-					`${field} coverage regressed ${regress.toFixed(1)}pp (${(prevCov * 100).toFixed(1)}% → ${(nowCov * 100).toFixed(1)}%)`,
+					`books with ${field} dropped ${prevCount} → ${nowCount} (-${dropPct.toFixed(1)}%) — existing values were destroyed`,
 				);
 			}
 		}

--- a/packages/web/src/lib/components/BookCard.svelte
+++ b/packages/web/src/lib/components/BookCard.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import type { Book } from '$lib/types';
 	import { subgenreLabels, subgenreColors, formatRuntime } from '$lib/types';
+	import { prefs } from '$lib/prefs.svelte';
 
 	let { book, onAuthorClick, onNarratorClick, onSeriesClick }: {
 		book: Book;
@@ -57,7 +58,7 @@
 
 		{#if book.seriesAsin && book.seriesName}
 			<!-- svelte-ignore a11y_no_static_element_interactions -->
-			<span class="series-line" role="button" tabindex="0" onclick={(e) => { e.preventDefault(); onSeriesClick?.(book.seriesAsin!); }} onkeydown={(e) => { if (e.key === 'Enter') { e.preventDefault(); onSeriesClick?.(book.seriesAsin!); }}}>{book.seriesName}{#if book.seriesPosition} &ndash; Book {book.seriesPosition}{/if}</span>
+			<span class="series-line" role="button" tabindex="0" onclick={(e) => { e.preventDefault(); onSeriesClick?.(book.seriesAsin!); }} onkeydown={(e) => { if (e.key === 'Enter') { e.preventDefault(); onSeriesClick?.(book.seriesAsin!); }}}>{#if prefs.isWatched(book.seriesAsin)}<span class="watched-star">★</span> {/if}{book.seriesName}{#if book.seriesPosition} &ndash; Book {book.seriesPosition}{/if}</span>
 		{/if}
 		<p class="meta-line">
 			{formatDate(book.releaseDate)}
@@ -219,6 +220,11 @@
 
 	.series-line:hover {
 		text-decoration-color: currentColor;
+	}
+
+	.watched-star {
+		color: var(--accent);
+		margin-right: 0.25em;
 	}
 
 .author {

--- a/packages/web/src/lib/components/BrowseModal.svelte
+++ b/packages/web/src/lib/components/BrowseModal.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import type { Book, ActiveFilter } from '$lib/types';
+	import { prefs } from '$lib/prefs.svelte';
 	import BookCard from './BookCard.svelte';
 
 	let {
@@ -46,6 +47,12 @@
 					<strong>{filter.label}</strong>
 				{/if}
 			</h2>
+			{#if filter.type === 'series'}
+				{@const watched = prefs.isWatched(filter.value)}
+				<button class="watch-btn" class:watched onclick={() => prefs.toggleWatchedSeries(filter.value)}>
+					{watched ? '★ Watching' : '☆ Watch'}
+				</button>
+			{/if}
 			<span class="modal-count">{books.length} title{books.length !== 1 ? 's' : ''}</span>
 			<button class="modal-close" onclick={handleClose}>&times;</button>
 		</div>
@@ -161,6 +168,30 @@
 		font-size: 0.7rem;
 		color: var(--text-muted);
 		white-space: nowrap;
+	}
+
+	.watch-btn {
+		font-family: var(--font-mono);
+		font-size: 0.7rem;
+		font-weight: 600;
+		color: var(--text-muted);
+		background: transparent;
+		border: 1px solid var(--border);
+		border-radius: 6px;
+		padding: 0.25rem 0.6rem;
+		cursor: pointer;
+		white-space: nowrap;
+		transition: color 0.15s, border-color 0.15s;
+	}
+
+	.watch-btn:hover {
+		color: var(--text-primary);
+		border-color: var(--text-muted);
+	}
+
+	.watch-btn.watched {
+		color: var(--accent);
+		border-color: var(--accent);
 	}
 
 	.modal-close {

--- a/packages/web/src/lib/components/FilterPopover.svelte
+++ b/packages/web/src/lib/components/FilterPopover.svelte
@@ -2,18 +2,24 @@
 	let {
 		seriesOnly,
 		longRunningOnly,
+		mySeriesOnly,
+		watchedCount,
 		onSeriesOnlyChange,
 		onLongRunningChange,
+		onMySeriesChange,
 	}: {
 		seriesOnly: boolean;
 		longRunningOnly: boolean;
+		mySeriesOnly: boolean;
+		watchedCount: number;
 		onSeriesOnlyChange: (v: boolean) => void;
 		onLongRunningChange: (v: boolean) => void;
+		onMySeriesChange: (v: boolean) => void;
 	} = $props();
 
 	let open = $state(false);
 
-	const activeCount = $derived((seriesOnly ? 1 : 0) + (longRunningOnly ? 1 : 0));
+	const activeCount = $derived((seriesOnly ? 1 : 0) + (longRunningOnly ? 1 : 0) + (mySeriesOnly ? 1 : 0));
 </script>
 
 <div class="filter-popover">
@@ -40,6 +46,13 @@
 				<span class="label-text">
 					Long-running series
 					<span class="label-desc">8+ books in the series</span>
+				</span>
+			</label>
+			<label class="filter-option">
+				<input type="checkbox" checked={mySeriesOnly} onchange={() => onMySeriesChange(!mySeriesOnly)} />
+				<span class="label-text">
+					My series
+					<span class="label-desc">{watchedCount === 0 ? 'Watch a series from its page first' : `Only the ${watchedCount} series you watch`}</span>
 				</span>
 			</label>
 		</div>

--- a/packages/web/src/lib/prefs.svelte.ts
+++ b/packages/web/src/lib/prefs.svelte.ts
@@ -21,6 +21,7 @@ interface PrefsV1 {
 	genres: Subgenre[];
 	seriesOnly: boolean;
 	longRunningOnly: boolean;
+	mySeriesOnly: boolean;
 }
 
 const DEFAULTS: PrefsV1 = {
@@ -31,7 +32,8 @@ const DEFAULTS: PrefsV1 = {
 	sort: 'relevance',
 	genres: [],
 	seriesOnly: false,
-	longRunningOnly: false
+	longRunningOnly: false,
+	mySeriesOnly: false
 };
 
 function load(): PrefsV1 {
@@ -93,8 +95,19 @@ class Prefs {
 		this.#persist();
 	}
 
+	get mySeriesOnly(): boolean {
+		return this.#data.mySeriesOnly;
+	}
+	set mySeriesOnly(v: boolean) {
+		this.#data.mySeriesOnly = v;
+		this.#persist();
+	}
+
 	get watchedSeries(): Set<string> {
 		return new Set(this.#data.watchedSeries);
+	}
+	isWatched(seriesAsin: string): boolean {
+		return this.#data.watchedSeries.includes(seriesAsin);
 	}
 	toggleWatchedSeries(seriesAsin: string): void {
 		this.#data.watchedSeries = toggleIn(this.#data.watchedSeries, seriesAsin);

--- a/packages/web/src/routes/[year]/+page.svelte
+++ b/packages/web/src/routes/[year]/+page.svelte
@@ -64,10 +64,13 @@
 		const monthIndices = quarterMonthIndices[activeQuarter];
 		const hiddenSeries = prefs.hiddenSeries;
 		const hiddenAuthors = prefs.hiddenAuthors;
+		const watched = prefs.watchedSeries;
+		const mySeriesOnly = prefs.mySeriesOnly;
 		return data.books
 			.filter((b) => {
 				if (!monthIndices.includes(monthOf(b))) return false;
 				if (activeGenres.size > 0 && !b.subgenres.some((g) => activeGenres.has(g))) return false;
+				if (mySeriesOnly && (!b.seriesAsin || !watched.has(b.seriesAsin))) return false;
 				if (seriesOnly && !b.seriesAsin) return false;
 				if (longRunningOnly) {
 					const pos = Number.parseFloat(b.seriesPosition ?? '');
@@ -221,8 +224,11 @@
 				<FilterPopover
 					{seriesOnly}
 					{longRunningOnly}
+					mySeriesOnly={prefs.mySeriesOnly}
+					watchedCount={prefs.watchedSeries.size}
 					onSeriesOnlyChange={(v) => (prefs.seriesOnly = v)}
 					onLongRunningChange={(v) => (prefs.longRunningOnly = v)}
+					onMySeriesChange={(v) => (prefs.mySeriesOnly = v)}
 				/>
 				<div class="sort-toggle">
 					<button


### PR DESCRIPTION
First slice of the localStorage user-state features on top of the prefs store from the rebuild:

- **Watch** a series from its browse modal (☆ Watch → ★ Watching)
- Watched series get a gold ★ on every book card's series line
- **My series** filter in the filter popover shows only books from series you watch (shows your watched count; hint text when you haven't watched any)
- Persisted in localStorage (versioned schema, keyed by stable series ASINs — survives re-exports/renames)

Also: export now drops Audible's far-future placeholder release dates (2200-01-01), which v1 data had leaked into the year picker.

Verified in browser: watch toggle reactivity across modal + cards, filter to exactly the watched series' releases, empty-state when the watched series has no releases that quarter.